### PR TITLE
CommandQueue: Lock read() and write() to avoid data race

### DIFF
--- a/eleeye/command-queue.cpp
+++ b/eleeye/command-queue.cpp
@@ -19,6 +19,8 @@ CommandQueue::CommandQueue() {
 }
 
 bool CommandQueue::write(const char *command) {
+
+    std::unique_lock<std::mutex> lk(mutex);
     
     if (strlen(commands[writeIndex]) != 0) {
         return false;
@@ -38,6 +40,8 @@ bool CommandQueue::write(const char *command) {
 }
 
 bool CommandQueue::read(char *dest) {
+
+    std::unique_lock<std::mutex> lk(mutex);
     
     if (readIndex == -1) return false;
 

--- a/eleeye/command-queue.h
+++ b/eleeye/command-queue.h
@@ -8,6 +8,8 @@
 #ifndef command_queue_h
 #define command_queue_h
 
+#include <mutex>
+
 class CommandQueue {
     
     enum {
@@ -17,6 +19,8 @@ class CommandQueue {
     
     char commands[MAX_COMMAND_COUNT][COMMAND_LENGTH];
     int readIndex, writeIndex;
+
+    std::mutex mutex;
     
 public:
     CommandQueue();


### PR DESCRIPTION
# 问题描述

增加代码，让 AI 和 AI 自对弈，概率性出现前端向引擎发出 `position fen ... moves ...`  命令，引擎接收不到，不返回结果，导致局面卡住。

# 复现概率

约  1/20 ~ 1/200 不等。

# 分析结论

通过在 `CommandQueue::read()` 和  `CommandQueue::write()`  函数增加打印，可知出现异常时，`CommandQueue::read()`  读取到的 readIndex 是 `-1`，观察 log，怀疑是时序问题。

# 修复方案

在  `CommandQueue::read()` 和  `CommandQueue::write()`  函数使用互斥锁保护共享资源。

# 验证结果

带上此修复，复验 AI 自对弈超过 2000 次未再复现问题。可以认为问题修复。